### PR TITLE
Edit match_variants functionality

### DIFF
--- a/bin/match_variants.py
+++ b/bin/match_variants.py
@@ -34,6 +34,12 @@ def read_target(path, plink_format):
         x = pl.read_csv(path, sep = '\t', has_header = False, comment_char = '##')
         x.columns = ['#CHROM', 'POS', 'ID', 'REF', 'ALT']
 
+        # Handle multi-allelic variants
+        is_ma = x['ALT'].str.contains(',')  # plink2 pvar multi-alleles are comma-separated
+        if is_ma.sum() > 0:
+            x.replace('ALT', x['ALT'].str.split(by=',')) # turn ALT to list of variants
+            x = x.explode('ALT') # expand the DF to have all the variants in different rows
+
     x = x.with_columns([
         (pl.col("REF").str.replace_all("A", "V")
             .str.replace_all("T", "X")

--- a/bin/match_variants.py
+++ b/bin/match_variants.py
@@ -18,6 +18,11 @@ def parse_args(args=None):
     parser.add_argument('--db', dest = 'db', help='<Required> path to database')
     parser.add_argument('-m', '--min_overlap', dest='min_overlap', required=True,
                         type = float, help='<Required> Minimum proportion of variants to match before error')
+    parser.add_argument('--keep-ambiguous', dest='keep_ambiguous', default=False, action='store_true',
+                        help='Flag to force the program to keep variants with ambiguous alleles, (e.g. A/T and G/C '
+                             'SNPs), which are normally excluded. In this case the program proceeds assuming that the '
+                             'genotype data is on the same strand as the GWAS whose summary statistics were used to '
+                             'construct the score.')
     return parser.parse_args(args)
 
 def read_target(path, plink_format):
@@ -104,7 +109,7 @@ def get_all_matches(target, scorefile, remove):
     altref = match_variants(scorefile, target, EA = 'ALT', OA = 'REF', match_type = "altref")
     refalt_flip = match_variants(scorefile, target, EA = 'REF_FLIP', OA = 'ALT_FLIP', match_type = "refalt_flip")
     altref_flip = match_variants(scorefile, target, EA = 'ALT_FLIP', OA = 'REF_FLIP', match_type = "altref_flip")
-    return label_biallelic_ambiguous(pl.concat([refalt, altref, refalt_flip, altref_flip]), remove)
+    return label_biallelic_ambiguous(pl.concat([refalt, altref, refalt_flip, altref_flip]), remove=args.keep_ambiguous)
 
 def label_biallelic_ambiguous(matches, remove):
     # A / T or C / G may match multiple times


### PR DESCRIPTION
Should allow handling of multi-allelic variant encoding in plink2 pvar files, and added a flag to keep ambiguous variants in the score calculation (e.g. when the same build)