### PR TITLE
Fix scorefile aggregation

### DIFF
--- a/bin/report.Rmd
+++ b/bin/report.Rmd
@@ -52,7 +52,7 @@ read_scorefiles <- function(path) {
 scorefiles <- list.files(pattern = "*.sscore", all.files = TRUE)
 combined <- purrr::map_dfr(scorefiles, read_scorefiles) %>%
   group_by(dataset, IID) %>%
-  summarise_all(sum)
+  summarise_all(sum, na.rm = TRUE)
 write.table(combined, "aggregated_scores.txt", col.names = TRUE, quote = FALSE, row.names = FALSE)
 ```
 


### PR DESCRIPTION
Fixes the return of all NAs in`aggregated_scores.txt` for scores that are not present in every scoring file. Equivalent to setting the fill_value = 0 in python/pandas

@nebfield this solves it but I'm not a tidyverse expert