### PR TITLE
Preload container images before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /usr/local/bin/nextflow
-          key: ${{ runner.os }}-${{ nxf_ver }}
+          key: ${{ runner.os }}-${{ env.nxf_ver }}
         
       - name: Install Nextflow
         if: steps.cache-nextflow-install.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,8 @@ jobs:
     name: Preload singularity images
     if: ${{ github.event_name == 'push'}}
     runs-on: ubuntu-latest
-
+    env:
+      NXF_SINGULARITY_CACHEDIR: "${{ github.workspace }}/singularity"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
@@ -69,12 +70,6 @@ jobs:
         run: |
           echo "/opt/hostedtoolcache/singularity/${{ env.SINGULARITY_VERSION }}/x64/bin" >> $GITHUB_PATH
 
-      - name: Set up singularity cache dir environment variable
-        run: |
-          # runner context isn't available in env workflow key
-          export NXF_SINGULARITY_CACHEDIR=${{ github.workspace }}/singularity
-          mkdir -p $NXF_SINGULARITY_CACHEDIR
-
       - name: Cache singularity images
         id: cache-singularity-pull
         uses: actions/cache@v3
@@ -85,9 +80,10 @@ jobs:
       - name: Pull and save singularity
         if: ${{ steps.cache-singularity-pull.outputs.cache-hit != 'true' }}
         run: |
+          mkdir -p $NXF_SINGULARITY_CACHEDIR          
           git grep 'ext.singularity*' conf/modules.config | cut -f 2 -d '=' | xargs -L 2 echo | tr -d ' ' > ${{ runner.temp }}/singularity_images.txt
           cat ${{ runner.temp }}/singularity_images.txt | sed 's/oras:\/\///;s/https:\/\///;s/\//-/g;s/$/.img/;s/:/-/' > ${{ runner.temp }}/singularity_image_paths.txt
-          paste -d '\n' ${{ runner.temp }}/singularity_image_paths.txt ${{ runner.temp }}/singularity_images.txt | xargs -L 2 sh -c 'singularity pull --disable-cache $NXF_SINGULARITY_CACHEDIR/$0 $1'
+          paste -d '\n' ${{ runner.temp }}/singularity_image_paths.txt ${{ runner.temp }}/singularity_images.txt | xargs -L 2 sh -c 'singularity pull --disable-cache --dir $NXF_SINGULARITY_CACHEDIR $0 $1'
 
   test:
     needs: [preload_docker, preload_singularity]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ env:
   SINGULARITY_VERSION: "3.8.3"
   NXF_ANSI_LOG: false
   CAPSULE_LOG: none  
-
+  NXF_SINGULARITY_CACHEDIR: "${{ github.workspace }}/singularity"
+  
 jobs:
   preload_docker:
     name: Preload docker images
@@ -46,8 +47,6 @@ jobs:
     name: Preload singularity images
     if: ${{ github.event_name == 'push'}}
     runs-on: ubuntu-latest
-    env:
-      NXF_SINGULARITY_CACHEDIR: "${{ github.workspace }}/singularity"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - dev
       - main
+      - ci
   pull_request:
     branches:
       - dev
@@ -71,7 +72,7 @@ jobs:
       - name: Set up singularity cache dir environment variable
         run: |
           # runner context isn't available in env workflow key
-          export NXF_SINGULARITY_CACHEDIR=${{ runner.temp }}/singularity
+          export NXF_SINGULARITY_CACHEDIR=${{ github.workspace }}/singularity
           mkdir -p $NXF_SINGULARITY_CACHEDIR
 
       - name: Cache singularity images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.sha }}
 
       - name: Load docker images from cache
-        if: matrix.profile == 'docker' && ${{ steps.restore-docker.outputs.cache-hit == 'true' }}
+        if: steps.restore-docker.outputs.cache-hit == 'true'
         run: |
           find $HOME -name '*.tar'
           find ${{ runner.temp }}/docker/ -name '*.tar' -exec sh -c 'docker load < {}' \;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,19 +102,11 @@ jobs:
       - name: Check out pipeline code
         uses: actions/checkout@v2
 
-      - name: Cache nextflow install
-        id: cache-nextflow-install
-        uses: actions/cache@v3
-        with:
-          path: /usr/local/bin/nextflow
-          key: ${{ runner.os }}-${{ nxf_ver }}
-        
       - name: Install Nextflow
-        if: steps.cache-nextflow-install.outputs.cache-hit != 'true'
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
-          
+
       - name: Restore docker cache
         id: restore-docker
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /usr/local/bin/nextflow
-          key: ${{ runner.os }}-${{ env.nxf_ver }}
+          key: ${{ runner.os }}-${{ nxf_ver }}
         
       - name: Install Nextflow
         if: steps.cache-nextflow-install.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ on:
 env:
   SINGULARITY_VERSION: "3.8.3"
   NXF_ANSI_LOG: false
-  CAPSULE_LOG: none  
+  CAPSULE_LOG: none
   NXF_SINGULARITY_CACHEDIR: "${{ github.workspace }}/singularity"
-  
+
 jobs:
   preload_docker:
     name: Preload docker images
@@ -79,7 +79,7 @@ jobs:
       - name: Pull and save singularity
         if: ${{ steps.cache-singularity-pull.outputs.cache-hit != 'true' }}
         run: |
-          mkdir -p $NXF_SINGULARITY_CACHEDIR          
+          mkdir -p $NXF_SINGULARITY_CACHEDIR
           git grep 'ext.singularity*' conf/modules.config | cut -f 2 -d '=' | xargs -L 2 echo | tr -d ' ' > ${{ runner.temp }}/singularity_images.txt
           cat ${{ runner.temp }}/singularity_images.txt | sed 's/oras:\/\///;s/https:\/\///;s/\//-/g;s/$/.img/;s/:/-/' > ${{ runner.temp }}/singularity_image_paths.txt
           paste -d '\n' ${{ runner.temp }}/singularity_image_paths.txt ${{ runner.temp }}/singularity_images.txt | xargs -L 2 sh -c 'singularity pull --disable-cache --dir $NXF_SINGULARITY_CACHEDIR $0 $1'
@@ -97,7 +97,6 @@ jobs:
         test_profile: ["test"]
         profile: ["docker", "singularity"]
         nxf_ver: ['22.10.0', ''] # minimum supported version, latest version
-    concurrency: ${{ matrix.test_profile }}
 
     steps:
       - name: Check out pipeline code
@@ -111,6 +110,7 @@ jobs:
       - name: Restore docker cache
         id: restore-docker
         uses: actions/cache@v3
+        if: matrix.profile == 'docker'
         with:
           path: ${{ runner.temp }}/docker
           key: ${{ runner.os }}-${{ github.sha }}
@@ -121,14 +121,34 @@ jobs:
           find $HOME -name '*.tar'
           find ${{ runner.temp }}/docker/ -name '*.tar' -exec sh -c 'docker load < {}' \;
 
-      - name: Run pipeline with test data on docker
-        if: matrix.profile == 'docker'
+      - name: Cache singularity setup
+        id: restore-singularity-setup
+        if: matrix.profile == 'singularity'
+        uses: actions/cache@v3
+        with:
+          path: /opt/hostedtoolcache/singularity/${{ env.SINGULARITY_VERSION }}/x64
+          key: ${{ runner.os }}-singularity-${{ env.SINGULARITY_VERSION }}
+
+      - name: Add singularity to path
+        if: steps.restore-singularity-setup.outputs.cache-hit == 'true'
+        run: |
+          echo "/opt/hostedtoolcache/singularity/${{ env.SINGULARITY_VERSION }}/x64/bin" >> $GITHUB_PATH
+
+      - name: Restore singularity cache
+        id: restore-singularity
+        uses: actions/cache@v3
+        if: matrix.profile == 'singularity'
+        with:
+          path: ${{ env.NXF_SINGULARITY_CACHEDIR }}
+          key: ${{ runner.os }}-${{ github.sha }}--singularity
+
+      - name: Run pipeline with test data
         continue-on-error: false
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.test_profile}},${{ matrix.profile }}
-    
+
   unit_test:
-    needs: [preload_docker, preload_singularity]      
+    needs: [preload_docker, preload_singularity]
     name: ${{ matrix.profile }} ${{ matrix.tags }}
     if: ${{ github.event_name == 'push'}}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         test_profile: ["test"]
-        profile: ["docker"]
+        profile: ["docker", "singularity"]
         nxf_ver: ['22.10.0', ''] # minimum supported version, latest version
     concurrency: ${{ matrix.test_profile }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ github.event_name == 'push'}}
     runs-on: ubuntu-latest
     env:
-      NXF_SINGULARITY_CACHEDIR: "${{ github.workspace }}/singularity"
+      NXF_SINGULARITY_CACHEDIR: "${{ runner.temp }}/singularity"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
         id: cache-singularity-pull
         uses: actions/cache@v3
         with:
-          path: $NXF_SINGULARITY_CACHEDIR
+          path: ${{ env.NXF_SINGULARITY_CACHEDIR }}
           key: ${{ runner.os }}-${{ github.sha }}--singularity
 
       - name: Pull and save singularity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,19 @@ jobs:
       - name: Check out pipeline code
         uses: actions/checkout@v2
 
+      - name: Cache nextflow install
+        id: cache-nextflow-install
+        uses: actions/cache@v3
+        with:
+          path: /usr/local/bin/nextflow
+          key: ${{ runner.os }}-${{ nxf_ver }}
+        
       - name: Install Nextflow
+        if: steps.cache-nextflow-install.outputs.cache-hit != 'true'
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
-
+          
       - name: Restore docker cache
         id: restore-docker
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           git grep 'ext.singularity*' conf/modules.config | cut -f 2 -d '=' | xargs -L 2 echo | tr -d ' ' > ${{ runner.temp }}/singularity_images.txt
           cat ${{ runner.temp }}/singularity_images.txt | sed 's/oras:\/\///;s/https:\/\///;s/\//-/g;s/$/.img/;s/:/-/' > ${{ runner.temp }}/singularity_image_paths.txt
-          paste -d '\n' ${{ runner.temp }}/singularity_image_paths.txt ${{ runner.temp }}/singularity_images.txt | xargs -L 2 sh -c 'singularity pull $NXF_SINGULARITY_CACHEDIR/$0 $1'
+          paste -d '\n' ${{ runner.temp }}/singularity_image_paths.txt ${{ runner.temp }}/singularity_images.txt | xargs -L 2 sh -c 'singularity pull --disable-cache $NXF_SINGULARITY_CACHEDIR/$0 $1'
 
   test:
     needs: [preload_docker, preload_singularity]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ github.event_name == 'push'}}
     runs-on: ubuntu-latest
     env:
-      NXF_SINGULARITY_CACHEDIR: "${{ runner.temp }}/singularity"
+      NXF_SINGULARITY_CACHEDIR: "${{ github.workspace }}/singularity"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2


### PR DESCRIPTION
* Github actions is configured to start one job for each test in the pytest-workflow suite 
* This makes it simpler to identify, fix, and rerun tests that may fail 
* Starting many jobs in parallel hammers the container registry, slowing down all tests
    * Instead, pull docker and singularity once then cache them
    * Before a test, load from the cache 
* Also cache reasonably complicated dependencies like singularity installation and set up 

The cache is currently configured to pull fresh images with each commit. This is a reasonable level of traffic for the container registry and avoids having stale caches. 