### PR TITLE
Improve variant selection for PCA

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -30,8 +30,8 @@ params {
     load_afreq = true
     geno_ref = 0.1
     mind_ref = 0.1
-    maf_ref = 0.01
-    hwe_ref = 0.000001
+    maf_ref = 0.05
+    hwe_ref = 0.0001
     indep_pairwise_ref = "1000 50 0.05"
     ld_grch37 = "$projectDir/assets/ancestry/high-LD-regions-hg19-GRCh37.txt"
     ld_grch38 = "$projectDir/assets/ancestry/high-LD-regions-hg38-GRCh38.txt"
@@ -42,9 +42,9 @@ params {
     projection_method = "oadp"
     ancestry_method = "RandomForest"
     ref_label = "SuperPop"
-    n_popcomp = 10
+    n_popcomp = 5
     normalization_method = "empirical mean mean+var"
-    n_normalization = 10
+    n_normalization = 4
 
     // compatibility params
     compat_params_file = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -115,7 +115,7 @@
                 },
                 "n_popcomp": {
                     "type": "integer",
-                    "default": 10,
+                    "default": 5,
                     "description": "Number of PCs used for population assignment"
                 },
                 "normalization_method": {
@@ -195,14 +195,14 @@
                 },
                 "maf_ref": {
                     "type": "number",
-                    "default": 0.01,
+                    "default": 0.05,
                     "description": "Exclude variants with allele frequency lower than a threshold (in reference genomes)",
                     "minimum": 0,
                     "maximum": 1
                 },
                 "hwe_ref": {
                     "type": "number",
-                    "default": 1e-06,
+                    "default": 1e-04,
                     "description": "Exclude variants with Hardy-Weinberg equilibrium exact test p-values below  a threshold (in reference genomes)",
                     "minimum": 0,
                     "maximum": 1


### PR DESCRIPTION
Fixes issues with population-specific genotyping errors that were causing problems with PCs 5/6 by making sure the variants are more common (MAF 5%) and adds less tolerance for variants that aren't in HWE. 