### PR TITLE
Avoid plink2_vcf errors

### DIFF
--- a/docs/how-to/prepare.rst
+++ b/docs/how-to/prepare.rst
@@ -17,7 +17,7 @@ Target genome data requirements
 - Only human chromosomes 1 -- 22, X, Y, and XY are supported by the pipeline,
   although sex chromosomes are rarely used in scoring files.
 - If input data contain other chromosomes (e.g. patch regions) then
-  the pipeline may probably complain loudly and stop calculating.
+  the pipeline may complain loudly and stop calculating.
 
 
 Supported file formats

--- a/docs/how-to/prepare.rst
+++ b/docs/how-to/prepare.rst
@@ -16,8 +16,8 @@ Target genome data requirements
 
 - Only human chromosomes 1 -- 22, X, Y, and XY are supported by the pipeline,
   although sex chromosomes are rarely used in scoring files.
-- If input data contain other chromosomes (e.g. pseudoautosomal regions) then
-  the pipeline will probably complain loudly and stop calculating.
+- If input data contain other chromosomes (e.g. patch regions) then
+  the pipeline may probably complain loudly and stop calculating.
 
 
 Supported file formats
@@ -41,10 +41,16 @@ VCF from an imputation server
     plink2 --vcf <full_path_to_vcf.vcf.gz> \
         --allow-extra-chr \
         --chr 1-22, X, Y, XY \
-        -make-pgen --out <1000G>_axy
+        -make-pgen --out <short name>_axy
+
+.. note:: Non-standard chromosomes/patches should not cause errors in versions >v2.0.0-alpha.3;
+    however, they will be be filtered out from the list of variants available for PGS scoring.
 
 VCF from WGS
 ------------
+
+See https://github.com/PGScatalog/pgsc_calc/discussions/123 for discussion about tools
+to convert the VCF files into ones suitable for calculating PGS.
 
 
 ``plink`` binary fileset (bfile)

--- a/modules/local/plink2_vcf.nf
+++ b/modules/local/plink2_vcf.nf
@@ -33,6 +33,7 @@ process PLINK2_VCF {
     def dosage_options = meta.vcf_import_dosage ? 'dosage=DS' : ''
     // rewriting genotypes, so use --max-alleles instead of using generic ID
     def set_ma_missing = params.keep_multiallelic ? '' : '--max-alleles 2'
+    def chrom_filter = meta.chrom == "ALL" ? "--chr 1-22, X, Y, XY" : "--chr ${meta.chrom}" // filter to canonical/stated chromosome
     newmeta = meta.clone() // copy hashmap for updating...
     newmeta.is_pfile = true // now it's converted to a pfile :)
 
@@ -45,6 +46,7 @@ process PLINK2_VCF {
         --missing vcols=fmissdosage,fmiss \\
         $args \\
         --vcf $vcf $dosage_options \\
+        --allow-extra-chr $chrom_filter \\
         --make-pgen vzs \\
         --out ${params.target_build}_${prefix}${meta.chrom}
 

--- a/tests/modules/plink2/vcf/main.nf
+++ b/tests/modules/plink2/vcf/main.nf
@@ -6,7 +6,7 @@ include { PLINK2_VCF } from '../../../../modules/local/plink2_vcf'
 
 workflow testvcf {
     vcf = file('https://gitlab.ebi.ac.uk/nebfield/test-datasets/-/raw/master/pgsc_calc/cineca_synthetic_subset.vcf.gz')
-    def meta = [id: 'test', is_vcf: true]
+    def meta = [id: 'test', is_vcf: true, chrom: '22']
 
     PLINK2_VCF(Channel.of([meta, vcf]))
 

--- a/tests/modules/plink2/vcf/test.yml
+++ b/tests/modules/plink2/vcf/test.yml
@@ -5,9 +5,9 @@
     - plink2
     - fast
   files:
-    - path: output/plink2/GRCh37_vcf_null.pgen
-    - path: output/plink2/GRCh37_vcf_null.psam
-    - path: output/plink2/GRCh37_vcf_null.pvar.zst
+    - path: output/plink2/GRCh37_vcf_22.pgen
+    - path: output/plink2/GRCh37_vcf_22.psam
+    - path: output/plink2/GRCh37_vcf_22.pvar.zst
     - path: output/plink2/versions.yml
       contains:
         - "plink2: 2.00a3.3"


### PR DESCRIPTION
This will avoid errors in the pipeline by:
- `--allow-extra-chr` allowing all chromosomes to be seen by plink
- In the case of a VCF with ALL variants: filtering to canonical chromosomes (1-22, X, Y, XY), e.g. removing patches
- If the VCF is for a single chromosome it will filter to only that chromosome

We don't do this for b/pfiles because the relabelled pvar would become out of sync.