### PR TITLE
Handle new reference 

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -51,4 +51,7 @@ process {
     withName:DUMPSOFTWAREVERSIONS {
         cache = false
     }
+    withLabel:plink2{
+        memory = { check_max( 16.GB * task.attempt, 'memory' ) }
+    }
 }

--- a/modules/local/ancestry/extract_database.nf
+++ b/modules/local/ancestry/extract_database.nf
@@ -17,18 +17,17 @@ process EXTRACT_DATABASE {
 
     output:
     tuple val(meta38), path("GRCh38_*_ALL.pgen"), path("GRCh38_*_ALL.psam"), path("GRCh38_*_ALL.pvar.zst"), emit: grch38, optional: true
-    tuple val(meta38), path("deg2_hg38.king.cutoff.out.id"), emit: grch38_king, optional: true
+    tuple val(meta38), path("GRCh38_*.king.cutoff.out.id"), emit: grch38_king, optional: true
     tuple val(meta37), path("GRCh37_*_ALL.pgen"), path("GRCh37_*_ALL.psam"), path("GRCh37_*_ALL.pvar.zst"), emit: grch37, optional: true
-    tuple val(meta37), path("deg2_phase3.king.cutoff.out.id"), emit: grch37_king, optional: true
+    tuple val(meta37), path("GRCh37_*.king.cutoff.out.id"), emit: grch37_king, optional: true
     path "versions.yml", emit: versions
 
     script:
     meta38 = ['build': 'GRCh38']
     meta37 = ['build': 'GRCh37']
-    def king = params.target_build == "GRCh37" ? "deg2_phase3.king.cutoff.out.id" : "deg2_hg38.king.cutoff.out.id"
 
     """
-    tar -xvf $reference --wildcards "${params.target_build}*" $king
+    tar -xvf $reference --wildcards "${params.target_build}*"
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process.tokenize(':').last()}:


### PR DESCRIPTION
ToDo: 

- [ ] Fix bootstrap_ancestry / setup_resource to rename the king files according to the new build pre-fixed pattern: `GRCh3#_{meta.id}.king.cutoff.out.id`, examples: GRCh37_gnomAD.king.cutoff.out.id, GRCh38_gnomAD.king.cutoff.out.id