### PR TITLE
Retry score and match_combine

### DIFF
--- a/modules/local/match_combine.nf
+++ b/modules/local/match_combine.nf
@@ -1,6 +1,7 @@
 process MATCH_COMBINE {
     // labels are defined in conf/modules.config
     label 'process_medium'
+    label 'error_retry'
     label 'pgscatalog_utils' // controls conda, docker, + singularity options
 
     // first element of tag must be sampleset

--- a/modules/local/plink2_score.nf
+++ b/modules/local/plink2_score.nf
@@ -3,6 +3,7 @@ process PLINK2_SCORE {
     // labels are defined in conf/modules.config
     label 'process_low'
     label 'process_long'
+    label 'error_retry'
     label 'plink2' // controls conda, docker, + singularity options
 
     tag "$meta.id chromosome $meta.chrom effect type $scoremeta.effect_type $scoremeta.n"


### PR DESCRIPTION
After checking user submitted issues these two processes sometimes exit with error code 137 because they can exhaust memory on medium sized datasets or larger. Retry them once to improve UX. Retries are automatically allocated with extra memory (2x original amount). 