### PR TITLE
Fix conda action on publish

### DIFF
--- a/.github/workflows/ancestry-conda.yml
+++ b/.github/workflows/ancestry-conda.yml
@@ -8,20 +8,11 @@ on:
         required: true
   
 jobs:
-  test_mamba_vcf:
+  test_mamba_ancestry:
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -el {0}
-    strategy:
-      fail-fast: false
-      matrix:
-        test_profile: ["test"]
-        profile: ["mamba"]
-        nxf_ver: ["22.10.0", ""]
-
-    env:
-      NXF_VER: ${{ matrix.nxf_ver }}
 
     steps:
       - name: Check out pipeline code

--- a/.github/workflows/ancestry-conda.yml
+++ b/.github/workflows/ancestry-conda.yml
@@ -1,0 +1,83 @@
+name: Run ancestry test with mamba profile
+
+on:
+  workflow_call:
+    inputs:
+      ancestry-cache-key:
+        type: string
+        required: true
+  
+jobs:
+  test_mamba_vcf:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        test_profile: ["test"]
+        profile: ["mamba"]
+        nxf_ver: ["22.10.0", ""]
+
+    env:
+      NXF_VER: ${{ matrix.nxf_ver }}
+
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v3
+
+      - name: Set environment variables
+        run: |
+          echo "ANCESTRY_REF_DIR=$RUNNER_TEMP" >> $GITHUB_ENV
+          echo "ANCESTRY_TARGET_DIR=$RUNNER_TEMP" >> $GITHUB_ENV
+
+      - name: Restore reference data
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ${{ env.ANCESTRY_TARGET_DIR }}/GRCh38_HAPNEST_TARGET_ALL.pgen
+            ${{ env.ANCESTRY_TARGET_DIR }}/GRCh38_HAPNEST_TARGET_ALL.psam
+            ${{ env.ANCESTRY_TARGET_DIR }}/GRCh38_HAPNEST_TARGET_ALL.pvar.zst
+            ${{ env.ANCESTRY_REF_DIR }}/GRCh38_HAPNEST_reference.tar.zst
+          key: ${{ inputs.ancestry-cache-key }}
+          fail-on-cache-miss: true
+  
+      - uses: conda-incubator/setup-miniconda@v2
+        with:  
+          channels: conda-forge,bioconda,defaults
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          python-version: "3.10"
+          
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+
+      - name: install nxf
+        run: |
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+
+      - name: Set up test requirements
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          
+      - run: pip install -r ${{ github.workspace }}/tests/requirements.txt
+
+      - name: Run ancestry test
+        run: TMPDIR=~ PROFILE=mamba pytest --kwdof --symlink --git-aware --wt 2 --tag "ancestry" --ignore tests/bin
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs-conda-ancestry
+          path: |
+            /home/runner/pytest_workflow_*/*/.nextflow.log
+            /home/runner/pytest_workflow_*/*/log.out
+            /home/runner/pytest_workflow_*/*/log.err
+            /home/runner/pytest_workflow_*/*/output/*

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -8,31 +8,39 @@ on:
 jobs:
   test_mamba_standard:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
     strategy:
       fail-fast: false
       matrix:
         test_profile: ["test"]
         profile: ["mamba"]
-        nxf_ver: ["22.10.0", "latest"]
+        nxf_ver: ["22.10.0", ""]
+
+    env:
+      NXF_VER: ${{ matrix.nxf_ver }}
 
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v3
 
+      - uses: conda-incubator/setup-miniconda@v2
+        with:  
+          channels: conda-forge,bioconda,defaults
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          python-version: "3.10"
+          
       - uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
           java-version: '17'
 
-      - uses: nf-core/setup-nextflow@v1
-        with:
-          version: ${{ matrix.nxf_ver }}
-          
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest          
-          channels: conda-forge,bioconda,defaults
+      - name: install nxf
+        run: |
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
 
       - name: Run pipeline with test data
         run: |

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,4 +1,4 @@
-name: test conda on publish
+name: test conda profiles on demand and on publish
 
 on:
   release:
@@ -6,6 +6,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  preload_ancestry:
+    uses: ./.github/workflows/preload-reference.yml
+
+  test_mamba_ancestry:
+    uses: ./.github/workflows/ancestry-conda.yml
+    needs: [preload_ancestry]
+    with:
+      ancestry-cache-key: ${{ needs.preload_ancestry.outputs.cache-key }}
+
   test_mamba_standard:
     runs-on: ubuntu-latest
     defaults:

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -21,19 +21,26 @@ class Utils {
         }
 
         // Check that all channels are present
-        def required_channels = ['conda-forge', 'bioconda', 'defaults']
-        def conda_check_failed = !required_channels.every { ch -> ch in channels }
+        // This channel list is ordered by required channel priority.
+        def required_channels_in_order = ['conda-forge', 'bioconda', 'defaults']
+        def channels_missing = ((required_channels_in_order as Set) - (channels as Set)) as Boolean
 
         // Check that they are in the right order
-        conda_check_failed |= !(channels.indexOf('conda-forge') < channels.indexOf('bioconda'))
-        conda_check_failed |= !(channels.indexOf('bioconda') < channels.indexOf('defaults'))
+        def channel_priority_violation = false
+        def n = required_channels_in_order.size()
+        for (int i = 0; i < n - 1; i++) {
+            channel_priority_violation |= !(channels.indexOf(required_channels_in_order[i]) < channels.indexOf(required_channels_in_order[i+1]))
+        }
 
-        if (conda_check_failed) {
+        if (channels_missing | channel_priority_violation) {
             log.warn "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
                 "  There is a problem with your Conda configuration!\n\n" +
                 "  You will need to set-up the conda-forge and bioconda channels correctly.\n" +
-                "  Please refer to https://bioconda.github.io/user/install.html#set-up-channels\n" +
-                "  NB: The order of the channels matters!\n" +
+                "  Please refer to https://bioconda.github.io/\n" +
+                "  The observed channel order is \n" +
+                "  ${channels}\n" +
+                "  but the following channel order is required:\n" +
+                "  ${required_channels_in_order}\n" +
                 "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         }
     }

--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -32,6 +32,8 @@ if ("$PROFILE" == "singularity") {
     singularity.autoMounts = true
 } else if ("$PROFILE" == "conda") {
     conda.enabled = true
+} else if ("$PROFILE" == "mamba") {
+    mamba.enabled = true
 } else if ("$PROFILE" == "arm") {
     docker.enabled         = true
     docker.userEmulation   = false

--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -33,7 +33,8 @@ if ("$PROFILE" == "singularity") {
 } else if ("$PROFILE" == "conda") {
     conda.enabled = true
 } else if ("$PROFILE" == "mamba") {
-    mamba.enabled = true
+    conda.enabled          = true
+    conda.useMamba         = true
 } else if ("$PROFILE" == "arm") {
     docker.enabled         = true
     docker.userEmulation   = false


### PR DESCRIPTION
closes #171 

* Fixes existing conda action (standard test)
* Set up conda ancestry action 
* Fix warning about default channels

note: conda actions use mamba because it solves environments quickly, we're just interested in making sure the environments can run the workflow