### PR TITLE
Version reference database with parameter

### DIFF
--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -31,6 +31,10 @@
 - [ ] Has the changelog been updated?
 - [ ] Update the nextflow schema
 
+# Reference panels
+- [ ] Did anything change to the modules for creating the reference panel? Bump ref_format_version in nextflow.config
+   - [ ] Publish new reference panels to FTP, update any documentation.
+
 # Tests
 
 - [ ] Make sure unit tests pass on singularity, docker, and conda (CI)

--- a/modules/local/ancestry/bootstrap/make_database.nf
+++ b/modules/local/ancestry/bootstrap/make_database.nf
@@ -26,7 +26,7 @@ process MAKE_DATABASE {
     """
     md5sum -c $checksums
 
-    echo $workflow.manifest.version > meta.txt
+    echo ${params.ref_format_version} > meta.txt
 
     # can't use meta variables in stageAs
     # don't want to use renameTo because it's destructive for the input

--- a/modules/local/ancestry/extract_database.nf
+++ b/modules/local/ancestry/extract_database.nf
@@ -31,7 +31,7 @@ process EXTRACT_DATABASE {
 
     DB_VERSION=\$(cat meta.txt)
 
-    if [ "\$DB_VERSION" != "2.0.0-alpha.3" ]; then
+    if [ "\$DB_VERSION" != "${params.ref_format_version}" ]; then
       echo "Old reference database version detected, please redownload the latest version and try again"
       echo "See https://pgsc-calc.readthedocs.io/en/latest/how-to/ancestry.html"
       exit 1

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,7 +22,7 @@ params {
     efo_direct                 = false
 
     // reference params
-    run_ancestry = null // path to reference database
+    run_ancestry = null // path to reference database TODO: replace with NO_FILE
     ancestry_checksums = "$projectDir/assets/ancestry/checksums.txt"
     // if you want to liftover --scorefiles, set the chain files
     hg19_chain = null // "https://hgdownload.cse.ucsc.edu/goldenpath/hg19/liftOver/hg19ToHg38.over.chain.gz"
@@ -37,7 +37,7 @@ params {
     ld_grch38 = "$projectDir/assets/ancestry/high-LD-regions-hg38-GRCh38.txt"
 
     // ancestry params
-    ancestry_params_file = null
+    ref_format_version = "v0.1"
     ref_samplesheet = "$projectDir/assets/ancestry/reference.csv"
     projection_method = "oadp"
     ancestry_method = "RandomForest"
@@ -47,7 +47,6 @@ params {
     n_normalization = 4
 
     // compatibility params
-    compat_params_file = null
     liftover = false
     target_build = null
     min_lift = 0.95
@@ -80,7 +79,7 @@ params {
     help                       = false
     validate_params            = true
     show_hidden_params         = false
-    schema_ignore_params       = 'only_bootstrap,only_input,only_compatible,only_match,only_projection,only_score,skip_ancestry,igenomes_ignore'
+    schema_ignore_params       = 'only_bootstrap,only_input,only_compatible,only_match,only_projection,only_score,skip_ancestry'
 
     // Max resource options
     // Defaults only, expecting to be overwritten


### PR DESCRIPTION
New internal parameter: `--ref_format_version`

Starting version at `v0.1`, previous database versions matched the workflow version, but we want to version them separately because references should rarely change