### PR TITLE
Remove storeDir semantic structure

### DIFF
--- a/modules/local/ancestry/ancestry_analysis.nf
+++ b/modules/local/ancestry/ancestry_analysis.nf
@@ -21,7 +21,6 @@ process ANCESTRY_ANALYSIS {
 
     script:
     """
-    # TODO: --ref_pcs is a horrible hack to select the first duplicate
     ancestry_analysis -d $meta.target_id \
         -r reference \
         --psam $ref_psam \

--- a/modules/local/ancestry/bootstrap/make_database.nf
+++ b/modules/local/ancestry/bootstrap/make_database.nf
@@ -3,7 +3,7 @@ process MAKE_DATABASE {
     label 'process_low'
     label 'zstd' // controls conda, docker, + singularity options
 
-    storeDir "${workDir.resolve()}/reference"
+    storeDir workDir / "reference"
 
     conda "${task.ext.conda}"
 

--- a/modules/local/ancestry/extract_database.nf
+++ b/modules/local/ancestry/extract_database.nf
@@ -3,7 +3,7 @@ process EXTRACT_DATABASE {
     label 'process_low'
     label 'zstd' // controls conda, docker, + singularity options
 
-    storeDir "${workDir.resolve()}/ref_extracted/"
+    storeDir workDir / "ancestry" / "ref_extracted"
 
     conda "${task.ext.conda}"
 

--- a/modules/local/ancestry/oadp/fraposa_pca.nf
+++ b/modules/local/ancestry/oadp/fraposa_pca.nf
@@ -5,8 +5,9 @@ process FRAPOSA_PCA {
 
     tag "reference"
     // permanently derive a PCA for each reference - sampleset combination
-    def baseDir = ( params.genotypes_cache ? "$params.genotypes_cache" : "${workDir.resolve()}" )
-    storeDir "${baseDir}/ancestry/fraposa/${params.target_build}/${ref_geno.baseName}/${targetmeta.id}/"
+    
+    cachedir = params.genotypes_cache ? file(params.genotypes_cache) : workDir
+    storeDir cachedir / "ancestry" / "fraposa_pca"
 
     conda "${task.ext.conda}"
 
@@ -20,9 +21,10 @@ process FRAPOSA_PCA {
     tuple val(targetmeta), path(target_geno)
 
     output:
-    path "*.{dat,pcs}", emit: pca
+    path "${output}*.{dat,pcs}", emit: pca
     path "versions.yml", emit: versions
 
+    output = "${params.target_build}_${meta.id}_${meta.chrom}"
     script:
     """
     fraposa ${ref_geno.baseName} \

--- a/modules/local/ancestry/oadp/fraposa_project.nf
+++ b/modules/local/ancestry/oadp/fraposa_project.nf
@@ -5,8 +5,8 @@ process FRAPOSA_PROJECT {
 
     tag "${target_geno.baseName.tokenize('_')[1]}"
     
-    def baseDir = ( params.genotypes_cache ? "$params.genotypes_cache" : "${workDir.resolve()}" )
-    storeDir "${baseDir}/ancestry/fraposa/${params.target_build}/${target_geno.baseName}/${split_fam.baseName}"
+    cachedir = params.genotypes_cache ? file(params.genotypes_cache) : workDir
+    storeDir cachedir / "ancestry" / "fraposa" / "project"
 
     conda "${task.ext.conda}"
 
@@ -21,12 +21,13 @@ process FRAPOSA_PROJECT {
         path(pca)
 
     output:
-    tuple val(oadp_meta), path("GRCh3?_${target_id}_*.pcs"), emit: pca
+    tuple val(oadp_meta), path("${output}.pcs"), emit: pca
     path "versions.yml", emit: versions
 
     script:
     target_id = target_geno.baseName.tokenize('_')[1]
     oadp_meta = ['target_id':target_id]
+    output = "${params.target_build}_${target_id}_${split_fam}"
     """
     fraposa ${ref_geno.baseName} \
         --method $params.projection_method \

--- a/modules/local/ancestry/oadp/intersect_thinned.nf
+++ b/modules/local/ancestry/oadp/intersect_thinned.nf
@@ -11,7 +11,8 @@ process INTERSECT_THINNED {
     label 'plink2' // controls conda, docker, + singularity options
 
     tag "$meta.id"
-    storeDir "${workDir.resolve()}/ancestry/thinned_intersection/${params.target_build}/${meta.id}"
+
+    storeDir workDir / "ancestry" / "thinned_intersections"
 
     conda "${task.ext.conda}"
 
@@ -24,10 +25,10 @@ process INTERSECT_THINNED {
     tuple val(meta), path(matched), path(pruned), val(geno_meta), path(genomes)
 
     output:
-    path("*_thinned.txt.gz"), emit: match_thinned
-    tuple val(geno_meta), path("*_extracted.pgen"), emit: geno
-    tuple val(geno_meta), path("*_extracted.pvar.gz"), emit: variants
-    tuple val(geno_meta), path("*_extracted.psam"), emit: pheno
+    path("${thin_output}.txt.gz"), emit: match_thinned
+    tuple val(geno_meta), path("${output}.pgen"), emit: geno
+    tuple val(geno_meta), path("${output}.pvar.gz"), emit: variants
+    tuple val(geno_meta), path("${output}.psam"), emit: pheno
     path "versions.yml"           , emit: versions
 
     script:
@@ -37,6 +38,8 @@ process INTERSECT_THINNED {
     // input options
     def input = (geno_meta.is_pfile) ? '--pfile' : '--bfile'
 
+    output = "${params.target_build}_${meta.id}_ALL_extracted"
+    thin_output = "${meta.id}_ALL_matched_thinned"
     """
     # 1) intersect thinned variants --------------------------------------------
 

--- a/modules/local/ancestry/oadp/plink2_makebed.nf
+++ b/modules/local/ancestry/oadp/plink2_makebed.nf
@@ -5,7 +5,8 @@ process PLINK2_MAKEBED {
     label "plink2" // controls conda, docker, + singularity options
 
     tag "$meta.id chromosome"
-    storeDir "${workDir.resolve()}/ancestry/bed/${geno.baseName}/"
+
+    storeDir workDir / "ancestry" / "bed"
 
     conda "${task.ext.conda}"
 
@@ -19,10 +20,10 @@ process PLINK2_MAKEBED {
     tuple val(meta), path(geno), path(pheno), path(variants), path(pruned)
 
     output:
-    tuple val(meta), path("*.bed"), emit: geno
-    tuple val(meta), path("*.bim"), emit: variants
-    tuple val(meta), path("*.fam"), emit: pheno
-    tuple val(meta), path("splitfam*"), emit: splits, optional: true
+    tuple val(meta), path("${output}.bed"), emit: geno
+    tuple val(meta), path("${output}.bim"), emit: variants
+    tuple val(meta), path("${output}.fam"), emit: pheno
+    tuple val(meta), path("${split_output}*"), emit: splits, optional: true
     path "versions.yml"           , emit: versions
 
     script:
@@ -33,7 +34,8 @@ process PLINK2_MAKEBED {
     def extract = pruned.name != 'NO_FILE' ? "--extract $pruned" : ''
     def extracted = pruned.name != 'NO_FILE' ? "_extracted" : ''
     def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}_" : "${meta.id}_"
-
+    output = "${params.target_build}_${prefix}${meta.chrom}${extracted}"
+    split_output = "${meta.id}_splitfam"
     """
     # use explicit flag because pfile prefix might be different
     plink2 \
@@ -45,11 +47,11 @@ process PLINK2_MAKEBED {
         --pvar $variants \
         --make-bed \
         $extract \
-        --out ${params.target_build}_${prefix}${meta.chrom}${extracted}
+        --out ${output}
 
     if [ $meta.id != 'reference' ]
     then
-        split -l 50000 <(grep -v '#' $pheno) splitfam
+        split -l 50000 <(grep -v '#' $pheno) ${split_output}
     fi
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/ancestry/oadp/plink2_orient.nf
+++ b/modules/local/ancestry/oadp/plink2_orient.nf
@@ -5,7 +5,8 @@ process PLINK2_ORIENT {
     label "plink2" // controls conda, docker, + singularity options
 
     tag "$meta.id"
-    storeDir "${workDir.resolve()}/ancestry/oriented/${geno.baseName}/"
+
+    storeDir = workDir / "ancestry" / "oriented"
 
     conda "${task.ext.conda}"
 
@@ -19,9 +20,9 @@ process PLINK2_ORIENT {
     tuple val(meta), path(geno), path(pheno), path(variants), path(ref_variants)
 
     output:
-    tuple val(meta), path("*.bed"), emit: geno
-    tuple val(meta), path("*.bim"), emit: variants
-    tuple val(meta), path("*.fam"), emit: pheno
+    tuple val(meta), path("${output}.bed"), emit: geno
+    tuple val(meta), path("${output}.bim"), emit: variants
+    tuple val(meta), path("${output}.fam"), emit: pheno
     path "versions.yml"           , emit: versions
 
     script:
@@ -30,7 +31,7 @@ process PLINK2_ORIENT {
 
     // output options
     def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}_" : "${meta.id}_"
-
+    output = "${params.target_build}_${prefix}${meta.chrom}_oriented"
     """
     plink2 \
         --threads $task.cpus \
@@ -41,7 +42,7 @@ process PLINK2_ORIENT {
         --bim $variants \
         --a1-allele $ref_variants 5 2 \
         --make-bed \
-        --out ${params.target_build}_${prefix}${meta.chrom}_oriented
+        --out $output
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process.tokenize(':').last()}:

--- a/modules/local/ancestry/relabel_ids.nf
+++ b/modules/local/ancestry/relabel_ids.nf
@@ -4,7 +4,9 @@ process RELABEL_IDS {
     label 'pgscatalog_utils' // controls conda, docker, + singularity options
 
     tag "$meta.id $meta.effect_type $target_format"
-    storeDir { refgeno.name != 'NO_FILE' ?  "${workDir.resolve()}/ancestry/relabel/${refgeno.baseName}/${meta.id}/" : false }
+
+    cachedir = workDir / "ancestry" / "relabel"
+    storeDir { refgeno.name != 'NO_FILE' ? cachedir : false }
 
     conda "${task.ext.conda}"
 

--- a/modules/local/match_combine.nf
+++ b/modules/local/match_combine.nf
@@ -6,7 +6,6 @@ process MATCH_COMBINE {
 
     // first element of tag must be sampleset
     tag "$meta.id"
-    scratch (workflow.containerEngine == 'singularity')
 
     conda "${task.ext.conda}"
 
@@ -19,7 +18,7 @@ process MATCH_COMBINE {
     tuple val(meta), path('???.ipc.zst'), path(scorefile), path(shared)
 
     output:
-    tuple val(scoremeta), path("*.scorefile.gz"), emit: scorefile
+    tuple val(scoremeta), path("*.scorefile"), emit: scorefile
     path "*_summary.csv"                        , emit: summary
     path "*_log.csv.gz"                         , emit: db
     path "versions.yml"                         ,  emit: versions
@@ -57,6 +56,7 @@ process MATCH_COMBINE {
         $combined_output \
         -v
 
+    gunzip *.scorefile.gz
     cat <<-END_VERSIONS > versions.yml
     ${task.process.tokenize(':').last()}:
         pgscatalog_utils: \$(echo \$(python -c 'import pgscatalog_utils; print(pgscatalog_utils.__version__)'))

--- a/modules/local/match_combine.nf
+++ b/modules/local/match_combine.nf
@@ -18,7 +18,7 @@ process MATCH_COMBINE {
     tuple val(meta), path('???.ipc.zst'), path(scorefile), path(shared)
 
     output:
-    tuple val(scoremeta), path("*.scorefile"), emit: scorefile
+    tuple val(scoremeta), path("*.scorefile.gz"), emit: scorefile
     path "*_summary.csv"                        , emit: summary
     path "*_log.csv.gz"                         , emit: db
     path "versions.yml"                         ,  emit: versions
@@ -56,7 +56,6 @@ process MATCH_COMBINE {
         $combined_output \
         -v
 
-    gunzip *.scorefile.gz
     cat <<-END_VERSIONS > versions.yml
     ${task.process.tokenize(':').last()}:
         pgscatalog_utils: \$(echo \$(python -c 'import pgscatalog_utils; print(pgscatalog_utils.__version__)'))

--- a/modules/local/match_variants.nf
+++ b/modules/local/match_variants.nf
@@ -5,7 +5,6 @@ process MATCH_VARIANTS {
 
     // first element of tag must be sampleset
     tag "$meta.id chromosome $meta.chrom"
-    scratch (workflow.containerEngine == 'singularity')
     errorStrategy 'finish'
 
     conda "${task.ext.conda}"

--- a/modules/local/plink2_relabelbim.nf
+++ b/modules/local/plink2_relabelbim.nf
@@ -5,8 +5,10 @@ process PLINK2_RELABELBIM {
     label "plink2" // controls conda, docker, + singularity options
 
     tag "$meta.id chromosome $meta.chrom"
-    storeDir ( params.genotypes_cache ? "$params.genotypes_cache/${meta.id}/${meta.build}/${meta.chrom}" :
-              "${workDir.resolve()}/genomes/${meta.id}/${meta.build}/${meta.chrom}")
+
+    cachedir = params.genotypes_cache ? file(params.genotypes_cache) : workDir
+    storeDir cachedir / "genomes" / "relabelled"
+
     conda "${task.ext.conda}"
 
     container "${ workflow.containerEngine == 'singularity' &&
@@ -19,10 +21,10 @@ process PLINK2_RELABELBIM {
     tuple val(meta), path(geno), path(variants), path(pheno)
 
     output:
-    tuple val(meta), path("${meta.build}_*.bed"), emit: geno
-    tuple val(meta), path("${meta.build}_*.zst"), emit: variants
-    tuple val(meta), path("${meta.build}_*.fam"), emit: pheno
-    tuple val(meta), path("*.vmiss.gz"), emit: vmiss
+    tuple val(meta), path("${output}.bed"), emit: geno
+    tuple val(meta), path("${output}.pvar.zst"), emit: variants
+    tuple val(meta), path("${output}.fam"), emit: pheno
+    tuple val(meta), path("${output}.vmiss.gz"), emit: vmiss
     path "versions.yml"           , emit: versions
 
     when:
@@ -36,7 +38,8 @@ process PLINK2_RELABELBIM {
     def mem_mb = task.memory.toMega() // plink is greedy
     // if dropping multiallelic variants, set a generic ID that won't match
     def set_ma_missing = params.keep_multiallelic ? '' : '--var-id-multi @:#'
-
+    // def limits scope to process block, so don't use it
+    output = "${meta.build}_${prefix}_${meta.chrom}"
     """
     plink2 \\
         --threads $task.cpus \\
@@ -47,12 +50,12 @@ process PLINK2_RELABELBIM {
         $set_ma_missing \\
         --bfile ${geno.baseName} $compressed \\
         --make-just-bim zs \\
-        --out ${meta.build}_${prefix}_${meta.chrom}
+        --out ${output}
 
     # cross platform (mac, linux) method of preserving symlinks
-    cp -a $geno ${meta.build}_${prefix}_${meta.chrom}.bed
-    cp -a $pheno ${meta.build}_${prefix}_${meta.chrom}.fam
-    gzip *.vmiss
+    cp -a $geno ${output}.bed
+    cp -a $pheno ${output}.fam
+    gzip ${output}.vmiss
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process.tokenize(':').last()}:

--- a/modules/local/plink2_relabelpvar.nf
+++ b/modules/local/plink2_relabelpvar.nf
@@ -6,8 +6,8 @@ process PLINK2_RELABELPVAR {
 
     tag "$meta.id chromosome $meta.chrom"
 
-    storeDir ( params.genotypes_cache ? "$params.genotypes_cache/${meta.id}/${meta.build}/${meta.chrom}" :
-              "${workDir.resolve()}/genomes/${meta.id}/${meta.build}/${meta.chrom}")
+    cachedir = params.genotypes_cache ? file(params.genotypes_cache) : workDir
+    storeDir cachedir / "genomes" / "relabelled"
 
     conda "${task.ext.conda}"
 
@@ -21,10 +21,10 @@ process PLINK2_RELABELPVAR {
     tuple val(meta), path(geno), path(pheno), path(variants)
 
     output:
-    tuple val(meta), path("${meta.build}_*.pgen"), emit: geno
-    tuple val(meta), path("${meta.build}_*.pvar.zst") , emit: variants
-    tuple val(meta), path("${meta.build}_*.psam"), emit: pheno
-    tuple val(meta), path("*.vmiss.gz"), emit: vmiss
+    tuple val(meta), path("${output}.pgen"), emit: geno
+    tuple val(meta), path("${output}.pvar.zst") , emit: variants
+    tuple val(meta), path("${output}.psam"), emit: pheno
+    tuple val(meta), path("${output}.vmiss.gz"), emit: vmiss
     path "versions.yml"            , emit: versions
 
     when:
@@ -38,7 +38,8 @@ process PLINK2_RELABELPVAR {
     def mem_mb = task.memory.toMega() // plink is greedy
     // if dropping multiallelic variants, set a generic ID that won't match
     def set_ma_missing = params.keep_multiallelic ? '' : '--var-id-multi @:#'
-
+    // def limits scope to process block, so don't use it
+    output = "${meta.build}_${prefix}_${meta.chrom}"
     """
     plink2 \\
         --threads $task.cpus \\
@@ -49,13 +50,13 @@ process PLINK2_RELABELPVAR {
         $set_ma_missing \\
         --pfile ${geno.baseName} $compressed \\
         --make-just-pvar zs \\
-        --out ${meta.build}_${prefix}_${meta.chrom}
+        --out $output
 
     # cross platform (mac, linux) method of preserving symlinks
-    cp -a $geno ${meta.build}_${prefix}_${meta.chrom}.pgen
-    cp -a $pheno ${meta.build}_${prefix}_${meta.chrom}.psam
+    cp -a $geno ${output}.pgen
+    cp -a $pheno ${output}.psam
    
-    gzip *.vmiss
+    gzip ${output}.vmiss
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process.tokenize(':').last()}:

--- a/modules/local/plink2_vcf.nf
+++ b/modules/local/plink2_vcf.nf
@@ -6,8 +6,8 @@ process PLINK2_VCF {
 
     tag "$meta.id chromosome $meta.chrom"
 
-    storeDir ( params.genotypes_cache ? "$params.genotypes_cache/${meta.id}/${meta.build}/${meta.chrom}" :
-              "${workDir.resolve()}/genomes/${meta.id}/${meta.build}/${meta.chrom}")
+    cachedir = params.genotypes_cache ? file(params.genotypes_cache) : workDir
+    storeDir cachedir / "genomes" / "recoded"
 
     conda "${task.ext.conda}"
 
@@ -20,10 +20,10 @@ process PLINK2_VCF {
     tuple val(meta), path(vcf)
 
     output:
-    tuple val(newmeta), path("${meta.build}_*.pgen"), emit: pgen
-    tuple val(newmeta), path("${meta.build}_*.psam"), emit: psam
-    tuple val(newmeta), path("${meta.build}_*.zst") , emit: pvar
-    tuple val(newmeta), path("${meta.build}_*.vmiss.gz"), emit: vmiss
+    tuple val(newmeta), path("${output}.pgen"), emit: pgen
+    tuple val(newmeta), path("${output}.psam"), emit: psam
+    tuple val(newmeta), path("${output}.pvar.zst") , emit: pvar
+    tuple val(newmeta), path("${output}.vmiss.gz"), emit: vmiss
     path "versions.yml"            , emit: versions
 
     script:
@@ -36,7 +36,8 @@ process PLINK2_VCF {
     def chrom_filter = meta.chrom == "ALL" ? "--chr 1-22, X, Y, XY" : "--chr ${meta.chrom}" // filter to canonical/stated chromosome
     newmeta = meta.clone() // copy hashmap for updating...
     newmeta.is_pfile = true // now it's converted to a pfile :)
-
+    // def limits scope to process block, so don't use it
+    output = "${meta.build}_${prefix}_${meta.chrom}_vcf"
     """
     plink2 \\
         --threads $task.cpus \\
@@ -48,9 +49,9 @@ process PLINK2_VCF {
         --vcf $vcf $dosage_options \\
         --allow-extra-chr $chrom_filter \\
         --make-pgen vzs \\
-        --out ${meta.build}_${prefix}_${meta.chrom}_vcf
+        --out ${output}
 
-    gzip *.vmiss
+    gzip ${output}.vmiss
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/subworkflows/local/ancestry/ancestry_project.nf
+++ b/subworkflows/local/ancestry/ancestry_project.nf
@@ -179,7 +179,7 @@ workflow ANCESTRY_PROJECT {
         .filter{ it instanceof Path && it.getName().contains('ALL') }
         .set { ch_ref_relabelled_variants }
 
-    target_extract = Channel.of(file('NO_FILE')) // optional input for PLINK2_MAKEBED
+    target_extract = Channel.of(file(projectDir / "assets" / "NO_FILE")) // optional input for PLINK2_MAKEBED
 
     // [meta, pgen, psam, relabelled pvar, optional_input]
     INTERSECT_THINNED.out.geno

--- a/subworkflows/local/apply_score.nf
+++ b/subworkflows/local/apply_score.nf
@@ -20,10 +20,20 @@ workflow APPLY_SCORE {
     main:
     ch_versions = Channel.empty()
 
-    scorefiles
-        .flatMap { annotate_scorefiles(it) }
-        .dump(tag: 'final_scorefiles', pretty: true)
-        .set { annotated_scorefiles }
+    scorefiles.map{ it ->
+        m = it.first().clone()
+        f = it.last()
+        def n = 0
+        f.withReader {
+            String line = it.readLine()
+            n = line.split("\t").length - 2 // ID, effect_allele
+        }
+        m.n_scores = n
+        return [m, f]
+    }.view()
+//        .flatMap { annotate_scorefiles(it) }
+//        .dump(tag: 'final_scorefiles', pretty: true)
+//        .set { annotated_scorefiles }
 
     geno
         .mix(pheno, variants)
@@ -63,6 +73,7 @@ workflow APPLY_SCORE {
             .set { ch_scorefile_relabel_input }
 
         // relabel scoring file ids to match reference format
+        // using a value channel 
         RELABEL_SCOREFILE_IDS ( ch_scorefile_relabel_input, Channel.value([[:], file("$projectDir/assets/NO_FILE")]) )
 
         RELABEL_SCOREFILE_IDS.out.relabelled
@@ -90,36 +101,36 @@ workflow APPLY_SCORE {
     }
 
     // intersect genomic data with split scoring files -------------------------
-    ch_genomes.target
-        .map { annotate_genomic(it) } // add n_samples
-        .dump( tag: 'final_genomes', pretty: true)
-        .cross ( annotated_scorefiles ) { m, it -> [m.id, m.chrom] }
-        .map { it.flatten() }
-        .mix( ch_apply_ref ) // add reference genomes!
-        .combine( ref_afreq.map { it.last() } ) // add allelic frequencies
-        .dump(tag: 'ready_to_score', pretty: true)
-        .set { ch_apply }
+    // ch_genomes.target
+    //     .map { annotate_genomic(it) } // add n_samples
+    //     .dump( tag: 'final_genomes', pretty: true)
+    //     .cross ( annotated_scorefiles ) { m, it -> [m.id, m.chrom] }
+    //     .map { it.flatten() }
+    //     .mix( ch_apply_ref ) // add reference genomes!
+    //     .combine( ref_afreq.map { it.last() } ) // add allelic frequencies
+    //     .dump(tag: 'ready_to_score', pretty: true)
+    //     .set { ch_apply }
 
-    PLINK2_SCORE ( ch_apply )
-    ch_versions = ch_versions.mix(PLINK2_SCORE.out.versions.first())
+    // PLINK2_SCORE ( ch_apply )
+    // ch_versions = ch_versions.mix(PLINK2_SCORE.out.versions.first())
 
     // [ [meta], [list, of, score, paths] ]
-    PLINK2_SCORE.out.scores
-        .collect()
-        .map { [ it.first(), it.tail().findAll { !(it instanceof LinkedHashMap) }]}
-        .set { ch_scores }
+    // PLINK2_SCORE.out.scores
+    //     .collect()
+    //     .map { [ it.first(), it.tail().findAll { !(it instanceof LinkedHashMap) }]}
+    //     .set { ch_scores }
 
-    SCORE_AGGREGATE ( ch_scores )
-    ch_versions = ch_versions.mix(SCORE_AGGREGATE.out.versions)
+    // SCORE_AGGREGATE ( ch_scores )
+    // ch_versions = ch_versions.mix(SCORE_AGGREGATE.out.versions)
 
-    // aggregated score output from this subworkflow is mandatory
-    def aggregate_fail = true
-    SCORE_AGGREGATE.out.scores.subscribe onNext: { aggregate_fail = false },
-      onComplete: { aggregate_error(aggregate_fail) }
+    // // aggregated score output from this subworkflow is mandatory
+    // def aggregate_fail = true
+    // SCORE_AGGREGATE.out.scores.subscribe onNext: { aggregate_fail = false },
+    //   onComplete: { aggregate_error(aggregate_fail) }
 
     emit:
     versions = ch_versions
-    scores = SCORE_AGGREGATE.out.scores
+    scores = Channel.empty() //SCORE_AGGREGATE.out.scores
 }
 
 def aggregate_error(boolean fail) {

--- a/subworkflows/local/report.nf
+++ b/subworkflows/local/report.nf
@@ -68,7 +68,7 @@ workflow REPORT {
         // make NO_FILE for each sampleset to join correctly later
         ancestry_results = ancestry_results.mix(
             ch_scores.map {it[0]} // unique samplesets
-                .combine(Channel.fromPath('NO_FILE'))
+                .combine(Channel.fromPath(file(projectDir / "assets" / "NO_FILE", checkIfExists: true)))
         )
     }
 
@@ -82,7 +82,10 @@ workflow REPORT {
         .combine(log_scorefiles) // all samplesets have the same scorefile metadata
         .set { ch_report_input }
 
-    SCORE_REPORT( ch_report_input, intersect_count, reference_panel_name )
+    Channel.fromPath(file(projectDir / "assets" /"report" / "report.qmd", checkIfExists: true))
+        .set{report_path}
+
+    SCORE_REPORT( ch_report_input, intersect_count, reference_panel_name, report_path )
     ch_versions = ch_versions.mix(SCORE_REPORT.out.versions)
 
     // if this workflow runs, the report must be written

--- a/workflows/pgsc_calc.nf
+++ b/workflows/pgsc_calc.nf
@@ -241,8 +241,8 @@ workflow PGSCCALC {
     // - intersect counts
     // optional inputs need different names to prevent collisions during stage in
     optional_intersect_count = file(projectDir / "assets" / "NO_FILE_INTERSECT_COUNT", checkIfExists: true)
-    ref_afreq = Channel.fromPath(optional_input)
-    intersect_count = Channel.fromPath(optional_intersect_count)
+    ref_afreq = Channel.value([[:], optional_input])
+    intersect_count = Channel.fromPath(optional_intersect_count, checkIfExists: true)
 
     if (run_ancestry_assign) {
         intersection = Channel.empty()

--- a/workflows/pgsc_calc.nf
+++ b/workflows/pgsc_calc.nf
@@ -145,6 +145,12 @@ if (params.platform) {
 workflow PGSCCALC {
     ch_versions = Channel.empty()
 
+    // some workflows require an optional input
+    // let's make one, and reuse it where possible
+    // see https://nextflow-io.github.io/patterns/optional-input/ which explains this odd implementation pattern
+    // these dummy files need to exist for cloud executors to work OK
+    optional_input = file(projectDir / "assets" / "NO_FILE", checkIfExists: true)
+
     //
     // SUBWORKFLOW: Create reference database for ancestry inference
     //
@@ -193,7 +199,7 @@ workflow PGSCCALC {
         // flatten the score channel
         ch_scorefiles = ch_scores.collect()
         // chain files are optional input
-        Channel.fromPath("$projectDir/assets/NO_FILE", checkIfExists: false).set { chain_files }
+        Channel.fromPath(optional_input).set { chain_files }
         if (params.hg19_chain && params.hg38_chain) {
             Channel.fromPath(params.hg19_chain, checkIfExists: true)
                 .mix(Channel.fromPath(params.hg38_chain, checkIfExists: true))
@@ -230,9 +236,13 @@ workflow PGSCCALC {
     // SUBWORKFLOW: Run ancestry projection
     //
 
-    // reference allelic frequencies are optional inputs to scoring subworkflow
-    ref_afreq = Channel.fromPath(file('NO_FILE'))
-    intersect_count = Channel.fromPath(file('NO_FILE_INTERSECT_COUNT'))
+    // this process has two optional inputs:
+    // - reference allelic frequencies 
+    // - intersect counts
+    // optional inputs need different names to prevent collisions during stage in
+    optional_intersect_count = file(projectDir / "assets" / "NO_FILE_INTERSECT_COUNT", checkIfExists: true)
+    ref_afreq = Channel.fromPath(optional_input)
+    intersect_count = Channel.fromPath(optional_intersect_count)
 
     if (run_ancestry_assign) {
         intersection = Channel.empty()
@@ -268,7 +278,7 @@ workflow PGSCCALC {
             // intersected variants ( across ref & target ) are an optional input
             intersection = ANCESTRY_PROJECT.out.intersection
         } else {
-            dummy_input = Channel.of(file('NO_FILE')) // dummy file that doesn't exist
+            dummy_input = Channel.of(optional_input) // dummy file that doesn't exist
             // associate each sampleset with the dummy file
             MAKE_COMPATIBLE.out.geno.map {
                 meta = it[0].clone()


### PR DESCRIPTION
Although we were only using stored files as a permanent cache and not publishing them, we were organising outputs into a semantic structure, e.g.:

```
storeDir $workDir/${meta.id}/${meta.chrom}
```

From [nextflow docs](https://www.nextflow.io/docs/latest/process.html#storedir):

> The storeDir directive is meant for long-term process caching and should not be used to publish output files or organize outputs into a semantic directory structure. In those cases, use the [publishDir](https://www.nextflow.io/docs/latest/process.html#publishdir) directive instead.

As a side effect this also broke cloud executors in subtle ways. 

Now flat directories are used and processes have been updated to correctly capture output file names, instead of using wildcards.