### PR TITLE
Fix cache names

### DIFF
--- a/modules/local/ancestry/oadp/fraposa_pca.nf
+++ b/modules/local/ancestry/oadp/fraposa_pca.nf
@@ -25,7 +25,7 @@ process FRAPOSA_PCA {
     path "versions.yml", emit: versions
 
     script:
-    output = "${params.target_build}_${meta.id}_${meta.chrom}"
+    output = "${params.target_build}_${meta.id}"
     """
     fraposa ${ref_geno.baseName} \
         --method $params.projection_method \

--- a/modules/local/ancestry/oadp/plink2_makebed.nf
+++ b/modules/local/ancestry/oadp/plink2_makebed.nf
@@ -33,7 +33,7 @@ process PLINK2_MAKEBED {
     // output options
     def extract = pruned.name != 'NO_FILE' ? "--extract $pruned" : ''
     def extracted = pruned.name != 'NO_FILE' ? "_extracted" : ''
-    def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}_" : "${meta.id}_"
+    def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
     output = "${params.target_build}_${prefix}${extracted}"
     split_output = "${meta.id}_splitfam"
     """

--- a/modules/local/ancestry/oadp/plink2_makebed.nf
+++ b/modules/local/ancestry/oadp/plink2_makebed.nf
@@ -4,7 +4,7 @@ process PLINK2_MAKEBED {
     label "${ params.copy_genomes ? 'copy_genomes' : '' }"
     label "plink2" // controls conda, docker, + singularity options
 
-    tag "$meta.id chromosome"
+    tag "$meta.id"
 
     storeDir workDir / "ancestry" / "bed"
 
@@ -34,7 +34,7 @@ process PLINK2_MAKEBED {
     def extract = pruned.name != 'NO_FILE' ? "--extract $pruned" : ''
     def extracted = pruned.name != 'NO_FILE' ? "_extracted" : ''
     def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}_" : "${meta.id}_"
-    output = "${params.target_build}_${prefix}${meta.chrom}${extracted}"
+    output = "${params.target_build}_${prefix}${extracted}"
     split_output = "${meta.id}_splitfam"
     """
     # use explicit flag because pfile prefix might be different

--- a/modules/local/ancestry/oadp/plink2_orient.nf
+++ b/modules/local/ancestry/oadp/plink2_orient.nf
@@ -30,8 +30,8 @@ process PLINK2_ORIENT {
     def mem_mb = task.memory.toMega() // plink is greedy
 
     // output options
-    def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}_" : "${meta.id}_"
-    output = "${params.target_build}_${prefix}${meta.chrom}_oriented"
+    def prefix = task.ext.suffix ? "_${meta.id}${task.ext.suffix}" : "_${meta.id}"
+    output = "${params.target_build}${prefix}_oriented"
     """
     plink2 \
         --threads $task.cpus \


### PR DESCRIPTION
Including the chromosome name in the MAKEBED outputs was causing problems with cacheing (e.g it would choose different chromosome IDs each time which caused the pipeline to re-run the projection steps, see slack).