### PR TITLE
Fix race condition in cache

### DIFF
--- a/subworkflows/local/ancestry/ancestry_project.nf
+++ b/subworkflows/local/ancestry/ancestry_project.nf
@@ -52,7 +52,7 @@ workflow ANCESTRY_PROJECT {
     ch_versions = ch_versions.mix(EXTRACT_DATABASE.out.versions.first())
 
     ch_db.map {
-        meta = it.first().clone()
+        def meta = [:].plus(it.first())
         meta.is_pfile = true
         meta.id = 'reference'
         meta.chrom = 'ALL'
@@ -119,7 +119,7 @@ workflow ANCESTRY_PROJECT {
 
     FILTER_VARIANTS.out.ref
         .map {
-            m = it.first().clone()
+            def m = [:].plus(it.first())
             m.id = 'reference'
             m.chrom = 'ALL'
             m.is_pfile = true

--- a/subworkflows/local/ancestry/bootstrap_ancestry.nf
+++ b/subworkflows/local/ancestry/bootstrap_ancestry.nf
@@ -76,7 +76,7 @@ workflow BOOTSTRAP_ANCESTRY {
 def drop_meta_keys(ArrayList it) {
     // input: [[meta hashmap], [file1, file2, file3]]
     // cloning is important when modifying the hashmap
-    m = it.first().clone()
+    def m = [:].plus(it.first())
     // dropping keys simplifies joining with build specific reference data
     m.remove('type')
     m.remove('is_pfile')

--- a/subworkflows/local/apply_score.nf
+++ b/subworkflows/local/apply_score.nf
@@ -154,9 +154,9 @@ def annotate_scorefiles(ArrayList scorefiles) {
     // the input meta map only contains keys 'id' (dataset ID) and 'is_vcf'
 
     // firstly, need to associate the scoremeta map with each individual scorefile
-    scoremeta = scorefiles.head()
-    scorefile_paths = scorefiles.tail().flatten()
-    return [[scoremeta], scorefile_paths].combinations()
+    def m = scorefiles.head()
+    def scorefile_paths = scorefiles.tail().flatten()
+    return [[m], scorefile_paths].combinations()
         // now annotate
         .collect {
             def scoremeta = [:]
@@ -190,15 +190,14 @@ def annotate_genomic(ArrayList target) {
     // OUTPUT:
     // [[meta], [pgen_path, psam_path, pvar_path]]
     // where meta map has been annotated with n_samples
-    // cloning is important or original instance will also be edited
 
-    meta = target.first().clone()
+    def meta = [:].plus(target.first()) 
     meta.id = meta.id.toString()
     meta.chrom = meta.chrom.toString()
 
-    paths = target.last()
-    sample = paths.collect { it ==~ /.*fam$|.*psam$/ }
-    psam = paths[sample.indexOf(true)]
+    def paths = target.last()
+    def sample = paths.collect { it ==~ /.*fam$|.*psam$/ }
+    def psam = paths[sample.indexOf(true)]
 
     def n = -1 // skip header
     psam.eachLine { n++ }
@@ -211,17 +210,16 @@ def count_scores(InputStream f) {
     // count number of calculated scores in a gzipped plink .scorefile
     // try-with-resources block automatically closes streams
     try (buffered = new BufferedReader(new InputStreamReader(new GZIPInputStream(f)))) {
-        n_extra_cols = 2 // ID, effect_allele
-        n_scores = buffered.readLine().split("\t").length - n_extra_cols
+        def n_extra_cols = 2 // ID, effect_allele
+        def n_scores = buffered.readLine().split("\t").length - n_extra_cols
         assert n_scores > 0 : "Counting scores failed, please check scoring file"
         return n_scores
     }
 }
 
-// TODO: turn this into a utility function
 def annotate_chrom(ArrayList it) {
     // extract chrom from filename prefix and add to hashmap
-    meta = it.first().clone()
+    def meta = [:].plus(it.first())
     meta.chrom = it.last().getBaseName().tokenize('_')[1]
     return [meta, it.last()]
 }

--- a/workflows/pgsc_calc.nf
+++ b/workflows/pgsc_calc.nf
@@ -281,7 +281,7 @@ workflow PGSCCALC {
             dummy_input = Channel.of(optional_input) // dummy file that doesn't exist
             // associate each sampleset with the dummy file
             MAKE_COMPATIBLE.out.geno.map {
-                meta = it[0].clone()
+                def meta = [:].plus(it[0])
                 meta = meta.subMap(['id'])
                 // one dummy file for groupTuple() size in match subworkflow
                 meta.n_chrom = 1


### PR DESCRIPTION
[A race condition was triggered by the use of global variables in closures](https://www.nextflow.io/docs/latest/cache-and-resume.html#race-condition-on-a-global-variable) with the new (fixed) `--genotypes_cache`

The race condition caused some scoring files to be silently dropped (i.e. not calculated) when working with target genomes split by chromosome. 

To fix the race condition we now:

* Make sure every variable in groovy functions are locally scoped
* Raise an error if each scoring file doesn't have a calculated score

**This probably only affected the dev branch**

## Race condition distribution

![image](https://github.com/PGScatalog/pgsc_calc/assets/11425618/a0287f92-4ff8-46f8-9456-fcc8f306e7de)

## Expected distribution

![good](https://github.com/PGScatalog/pgsc_calc/assets/11425618/90fd96a9-7255-44b5-89fc-cacdcdb06a8d)
