### PR TITLE
Set defaultBranch to v2.0.0-alpha.5

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -265,7 +265,7 @@ dag {
 manifest {
     name            = 'pgscatalog/pgsc_calc'
     author          = 'Samuel Lambert, Benjamin Wingfield'
-    defaultBranch   = 'main'
+    defaultBranch   = '2_alpha_5'
     homePage        = 'https://github.com/pgscatalog/pgsc_calc'
     description     = 'The Polygenic Score Catalog Calculator is a nextflow pipeline for polygenic score calculation'
     mainScript      = 'main.nf'


### PR DESCRIPTION
The nextflow config `manifest.defaultBranch` only supports branches, not tags, so I made a branch with:

```
$ git checkout -b 2_alpha_5 v2.0.0-alpha.5
```

This will prevent people from having to specify a revision to avoid using alpha.6 - which is currently a pre-release - when installing or running the calculator with `nextflow run pgscatalog/pgsc_calc ...`