### PR TITLE
Write consistent column sets to variant information files

### DIFF
--- a/lib/SamplesheetParser.groovy
+++ b/lib/SamplesheetParser.groovy
@@ -168,7 +168,7 @@ class SamplesheetParser {
         def samplesets = rows.collect { row -> row.sampleset }
         def n_samplesets = samplesets.toSet().size()
         if (n_samplesets > 1) {
-            Nextflow.error("${n_samplesets} missing chromosomes detected! Maximum is 1. Check your samplesheet.")
+            Nextflow.error("${n_samplesets} samplesets detected! Maximum is 1. Check your samplesheet.")
         }
     }
 
@@ -177,7 +177,7 @@ class SamplesheetParser {
         def n_bad_name = samplesets.count { it == "reference" | it.contains("_") }
 
         if (n_bad_name != 0) {
-            Nextflow.error("Reserved sampleset name detected. Please don't call your sampleset 'reference'")
+            Nextflow.error("Reserved sampleset name/character detected. DO NOT call your sampleset 'reference' or use underscores ('_') in the name.")
         }
     }
 

--- a/modules/local/plink2_relabelpvar.nf
+++ b/modules/local/plink2_relabelpvar.nf
@@ -51,7 +51,7 @@ process PLINK2_RELABELPVAR {
         --set-all-var-ids '@:#:\$r:\$a' \\
         $set_ma_missing \\
         --pfile ${geno.baseName} $compressed \\
-        --make-just-pvar zs \\
+        --make-just-pvar zs cols="-xheader,-maybequal,-maybefilter,-maybeinfo,-maybecm" \\
         --out $output
 
     # -a: cross platform (mac, linux) method of preserving symlinks

--- a/modules/local/plink2_vcf.nf
+++ b/modules/local/plink2_vcf.nf
@@ -50,7 +50,7 @@ process PLINK2_VCF {
         $args \\
         --vcf $vcf $dosage_options \\
         --allow-extra-chr $chrom_filter \\
-        --make-pgen vzs \\
+        --make-pgen vzs pvar-cols="-xheader,-maybequal,-maybefilter,-maybeinfo,-maybecm" \\
         --out ${output}
 
     gzip ${output}.vmiss


### PR DESCRIPTION
* pvar files can contain extra columns
* when `pgscatalog-match` reads pvar files with extra columns it can trigger ` polars.exceptions.ComputeError: found more fields than defined in 'Schema'`
* this problem mostly affects complex VCFs that get recoded
* this PR writes a consistent column set during initial relabelling or recoding 

closes https://github.com/PGScatalog/pgsc_calc/issues/324 