### PR TITLE
remove default anaconda channels

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -43,7 +43,7 @@ process {
     }
 
     withLabel: plink2 {
-        ext.conda = "bioconda::plink2==2.00a5.10"
+        ext.conda = "$projectDir/environments/plink2/environment.yml"
         ext.docker = 'ghcr.io/pgscatalog/plink2'
         ext.singularity = 'oras://ghcr.io/pgscatalog/plink2'
         ext.docker_version = ':2.00a5.10'
@@ -67,7 +67,7 @@ process {
     }
 
     withLabel: pyyaml {
-        ext.conda = "conda-forge::pyyaml==6.0"
+        ext.conda = "$projectDir/environments/pyyaml/environment.yml"
         ext.singularity = 'oras://ghcr.io/pgscatalog/pyyaml'
         ext.singularity_version = ':6.0-singularity'
         ext.docker = 'ghcr.io/pgscatalog/pyyaml'

--- a/environments/fraposa/environment.yml
+++ b/environments/fraposa/environment.yml
@@ -2,5 +2,6 @@ name: fraposa-pgsc
 channels:
   - conda-forge
   - bioconda
+  - nodefaults  
 dependencies:
-- fraposa-pgsc=1.0.0
+  - fraposa-pgsc=1.0.0

--- a/environments/pgscatalog_utils/environment.yml
+++ b/environments/pgscatalog_utils/environment.yml
@@ -2,5 +2,6 @@ name: pgscatalog-utils
 channels:
   - conda-forge
   - bioconda
+  - nodefaults  
 dependencies:
-- pgscatalog-utils=1.1.2
+  - pgscatalog-utils=1.1.2

--- a/environments/plink2/environment.yml
+++ b/environments/plink2/environment.yml
@@ -1,7 +1,7 @@
-name: zstd
+name: plink2
 channels:
   - conda-forge
   - bioconda
   - nodefaults  
-dependencies:
-  - zstd=1.4.8
+dependencies: 
+  - plink2==2.00a5.10

--- a/environments/pyyaml/environment.yml
+++ b/environments/pyyaml/environment.yml
@@ -2,5 +2,6 @@ name: pyyaml
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
-- pyyaml=6.0.1
+  - pyyaml=6.0.1

--- a/environments/pyyaml/environment.yml
+++ b/environments/pyyaml/environment.yml
@@ -2,6 +2,5 @@ name: pyyaml
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
 - pyyaml=6.0.1

--- a/environments/report/environment.yml
+++ b/environments/report/environment.yml
@@ -2,6 +2,7 @@ name: report
 channels:
   - conda-forge
   - bioconda
+  - nodefaults  
 dependencies: 
   - r-jsonlite
   - r-dplyr


### PR DESCRIPTION
See https://stackoverflow.com/q/74762863, non-profits and academia were exempt from the license change until July 31st

These license terms don't apply to the conda-forge or bioconda channels

This mostly affects end users looking to install the calculator with the conda profile