### PR TITLE
Don't filter TARGET variants for MAF by default, the missingness filt…

### DIFF
--- a/docs/explanation/geneticancestry.rst
+++ b/docs/explanation/geneticancestry.rst
@@ -134,11 +134,9 @@ how-to guide), and has the following steps:
         the default settings can be changed (see :doc:`schema (Reference options) <params>`).
 
         1.  **Additional variant filters on TARGET samples**: in ``v2.0.0-beta`` we introduced the ability to filter
-            target sample variants using minimum MAF [default 10%] and maximum genotype missingness [default 10%] to
+            target sample variants using a maximum genotype missingness [default 10%] and/or minimum MAF [default 0%] to
             improve PCA robustness when using imputed genotype data (see :doc:`schema (Ancestry options) <params>`).
-            *Note: these parameters may need to be adjusted depending on your input data (currently optimized for large
-            cohorts like UKB), for individual samples we recommend the MAF filter to be lowered (``--pca_maf_target 0``)
-            to ensure homozygous reference calls are included.*
+            *Note: these parameters may need to be adjusted depending on your input data.*
 
     2.  **PCA**: the LD-pruned variants of the unrelated samples passing QC are then used to define the PCA space of the
         reference panel (default: 10 PCs) using `FRAPOSA`_ (Fast and Robust Ancestry Prediction by using Online singular

--- a/nextflow.config
+++ b/nextflow.config
@@ -43,7 +43,7 @@ params {
     n_popcomp = 5
     normalization_method = "empirical mean mean+var"
     n_normalization = 4
-    pca_maf_target = 0.1
+    pca_maf_target = 0
     pca_geno_miss_target = 0.1
 
     // compatibility params

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -168,7 +168,7 @@
         },
         "pca_maf_target": {
           "type": "number",
-          "default": 0.1,
+          "default": 0,
           "description": "Minimum MAF threshold in TARGET samples for variants to be included in the PCA.",
           "minimum": 0,
           "maximum": 1


### PR DESCRIPTION
…er remains the same.