### PR TITLE
feat: support cloud storage URIs in CSV samplesheet path_prefix

### DIFF
--- a/lib/SamplesheetParser.groovy
+++ b/lib/SamplesheetParser.groovy
@@ -133,7 +133,7 @@ class SamplesheetParser {
 
     private def resolvePath(path) {
         // paths in a CSV samplesheet might be relative, and should be resolved from the samplesheet path
-        def is_absolute = path.startsWith('/') // isAbsolute() was causing weird issues
+        def is_absolute = path.startsWith('/') || path.matches('^[a-zA-Z][a-zA-Z0-9+.-]*://.*') // isAbsolute() was causing weird issues
 
         def resolved_path
         if (is_absolute) {

--- a/lib/SamplesheetParser.groovy
+++ b/lib/SamplesheetParser.groovy
@@ -133,7 +133,14 @@ class SamplesheetParser {
 
     private def resolvePath(path) {
         // paths in a CSV samplesheet might be relative, and should be resolved from the samplesheet path
-        def is_absolute = path.startsWith('/') || path.matches('^[a-zA-Z][a-zA-Z0-9+.-]*://.*') // isAbsolute() was causing weird issues
+        def is_cloud_uri = path.matches('^[a-zA-Z][a-zA-Z0-9+.-]*://.*')
+        def is_absolute = path.startsWith('/') // isAbsolute() was causing weird issues
+
+        if (is_cloud_uri) {
+            // cloud URIs (gs://, s3://) are already absolute, return as string
+            // so that suffix concatenation works downstream
+            return path
+        }
 
         def resolved_path
         if (is_absolute) {


### PR DESCRIPTION
## Summary

Closes #484

Adds support for cloud storage URIs (`gs://`, `s3://`, etc.) in the `path_prefix` column of CSV samplesheets.

### Problem

`SamplesheetParser.resolvePath()` treats any path not starting with `/` as relative and resolves it against the samplesheet's parent directory. A `path_prefix` like `gs://bucket/path/sample` gets mangled into a local path.

Additionally, Nextflow's cloud path objects (e.g. `GcsPath`) don't support string concatenation for suffix appending, causing downstream failures even if path resolution is fixed.

### Fix

- Detect URI schemes (`gs://`, `s3://`, etc.) via regex and return them early as plain strings, bypassing relative path resolution
- Returning as strings (rather than Nextflow path objects) ensures suffix concatenation works correctly downstream

## Test plan

- [x] CSV samplesheet with `gs://` path_prefix works on GCP
- [x] CSV samplesheet with `s3://` path_prefix works on AWS
- [x] Local relative and absolute paths still resolve correctly