### PR TITLE
fix: change scorefiles to queue channel to reduce memory usage

### DIFF
--- a/assets/report/report.qmd
+++ b/assets/report/report.qmd
@@ -85,7 +85,8 @@ cat command.txt | fold -w 80 -s | awk -F ' ' 'NR==1 { print "$", $0} NR>1 { prin
 ## 1.3 Scoring file metadata
 
 ```{r load_scorefiles}
-json_list <- jsonlite::fromJSON(params$log_scorefiles, simplifyVector = FALSE)
+json_files <- list.files(pattern = "\\.json$", full.names = TRUE)
+json_list <- lapply(json_files, jsonlite::fromJSON, simplifyVector = FALSE) |> unlist(recursive = FALSE)
 
 link_traits <- function(trait_efo, mapped) {
   if (length(trait_efo) == 0) {

--- a/modules/local/match_combine.nf
+++ b/modules/local/match_combine.nf
@@ -33,7 +33,6 @@ process MATCH_COMBINE {
     scoremeta = [:]
     scoremeta.id = "$meta.id"
 
-    script:
     if (shared.name == "NO_FILE")
         """
         export POLARS_MAX_THREADS=$task.cpus

--- a/modules/local/score_report.nf
+++ b/modules/local/score_report.nf
@@ -13,7 +13,8 @@ process SCORE_REPORT {
         "${task.ext.docker}${task.ext.docker_version}" }"
 
     input:
-    tuple val(meta), path(scorefile), path(score_log), path(match_summary), path(ancestry)
+    tuple val(meta), path(scorefile), path(match_summary), path(ancestry)
+    path log_scorefiles, stageAs: "???_log_scorefile.json"
     path intersect_count
     val reference_panel_name
     path(report_path, arity: '4') // 4 files expected: report, css, background image x2

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -9,7 +9,7 @@ workflow INPUT_CHECK {
     take:
     input_path // file: /path/to/samplesheet.csv
     format // csv or JSON
-    scorefile // flat list of paths
+    scorefile // queue channel of paths
     chain_files
 
     main:

--- a/subworkflows/local/match.nf
+++ b/subworkflows/local/match.nf
@@ -12,11 +12,8 @@ workflow MATCH {
     main:
     ch_versions = Channel.empty()
 
-    // convert to a nested list of length 1 [[scorefile1_path, scorefile2_path]]
-    scorefiles = scorefile.collect { [it] }
-
     variants
-        .combine(scorefiles)
+        .combine(scorefile)
         .dump(tag: 'match_variants_input', pretty: true)
         .set { ch_variants }
 
@@ -54,7 +51,7 @@ workflow MATCH {
 
     combine_meta
         .concat( ch_matches.matches.collect() )
-        .concat( scorefile )
+        .concat( scorefile.collect() )
         .concat( ch_intersection_grouped.intersections.collect() )
         .buffer( size: 4 )
         .dump ( tag: 'match_combine_input', pretty: true )

--- a/subworkflows/local/report.nf
+++ b/subworkflows/local/report.nf
@@ -79,7 +79,6 @@ workflow REPORT {
     ch_scores
         .join(ch_annotated_log, by: 0)
         .join(ancestry_results, by: 0)
-        .combine(log_scorefiles) // all samplesets have the same scorefile metadata
         .set { ch_report_input }
 
     Channel.fromPath([file(projectDir / "assets" /"report" / "report.qmd", checkIfExists: true),
@@ -88,8 +87,10 @@ workflow REPORT {
         file(projectDir / "assets" /"report" / "pgs_header_background.png", checkIfExists: true)])
       .collect()
       .set{ report_path }
+    
+    ch_log_scorefiles = log_scorefiles.collect()
 
-    SCORE_REPORT( ch_report_input, intersect_count, reference_panel_name, report_path )
+    SCORE_REPORT( ch_report_input, ch_log_scorefiles, intersect_count, reference_panel_name, report_path )
     ch_versions = ch_versions.mix(SCORE_REPORT.out.versions)
 
     emit:

--- a/workflows/pgsc_calc.nf
+++ b/workflows/pgsc_calc.nf
@@ -208,21 +208,21 @@ workflow PGSCCALC {
 
     if (run_input_check) {
         // flatten the score channel
-        ch_scorefiles = ch_scores.collect()
+        ch_scorefiles = ch_scores.flatten()
         // chain files are optional input
-        Channel.fromPath(optional_input).set { chain_files }
+        chain_files = Channel.empty()
         if (params.hg19_chain && params.hg38_chain) {
             Channel.fromPath(params.hg19_chain, checkIfExists: true)
                 .mix(Channel.fromPath(params.hg38_chain, checkIfExists: true))
-                .collect()
                 .set { chain_files }
         }
+        ch_chain_files = chain_files.ifEmpty { optional_input }.collect()
 
         INPUT_CHECK (
             params.input,
             params.format,
             ch_scorefiles,
-            chain_files
+            ch_chain_files
         )
         ch_versions = ch_versions.mix(INPUT_CHECK.out.versions)
     }


### PR DESCRIPTION
Fix for https://github.com/PGScatalog/pgsc_calc/issues/475

Splits scores into a queue channel after the `DOWNLOAD_SCOREFILES` process so each score file is formatted individually in the downstream analyses, without modifying match processes. Report process and template also modified in order to handle multiple json score metadata files instead of a single json file. Subtle changes in handling chain files to accommodate the use of a queue channel as input into `FORMAT_SCOREFILES`.

Aimed to only make workflow changes and not modify any processes; will likely look at the pygscatalog repo later to check out memory usage there. 

Draft because still in the process of testing things thoroughly, but if there's anything major I missed let me know so I can modify. Checking mechanics locally things seem to be fine, but the tests already present in the repo all run off their own little nf scripts; browsing through there isn't something that will easily confirm the behavior of the changes I made since it's mostly workflow related. Also need a test set to test liftover, modified that channel a bit in order to properly pass in the chain files multiple times. 

copilot's summary below:

**Scorefile and log file handling improvements:**

* Changed the `scorefile` input in `INPUT_CHECK` to a queue channel for better compatibility with Nextflow's channel operations, and updated downstream usage accordingly. [[1]](diffhunk://#diff-a8833e8e0c955fce1c60c57e1b287c0de31fb1ca536fcacd976f1536b0b178f3L12-R12) [[2]](diffhunk://#diff-e3514c57b99ca25286d851db93415502b30bbdb75b404624a524f436317d59f4L15-R16) [[3]](diffhunk://#diff-e3514c57b99ca25286d851db93415502b30bbdb75b404624a524f436317d59f4L57-R54)
* Updated the `SCORE_REPORT` process to accept `log_scorefiles` as a separate input, ensuring that scorefile metadata is passed explicitly and consistently. [[1]](diffhunk://#diff-2be47d97a425257229932579803712784772e6438bfe8757fc95a2965d85b66aL16-R17) [[2]](diffhunk://#diff-0a053685978d10d2f48eafc455163a792a1980fdff59f0aafdf9ffd2a06f67c8L92-R93)
* Modified the `REPORT` workflow to collect `log_scorefiles` into a channel before passing to `SCORE_REPORT`, and removed an unnecessary combine operation. [[1]](diffhunk://#diff-0a053685978d10d2f48eafc455163a792a1980fdff59f0aafdf9ffd2a06f67c8L82) [[2]](diffhunk://#diff-0a053685978d10d2f48eafc455163a792a1980fdff59f0aafdf9ffd2a06f67c8L92-R93)

**Scorefile metadata loading:**

* Updated the report generation script (`report.qmd`) to load all JSON files in the working directory, rather than relying on a single path from parameters, allowing for more flexible metadata aggregation.

**Workflow input and channel management:**

* Improved the handling of optional chain files and scorefile flattening in the main `PGSCCALC` workflow to ensure correct input types and avoid issues with empty channels.